### PR TITLE
fix RangeError, add entity cap

### DIFF
--- a/__test__/index.test.js
+++ b/__test__/index.test.js
@@ -66,5 +66,10 @@ test('multiple', () => {
 test('no descendants', () => {
   let curies = ['DOID:0060527'];
   let descendants = getDescendants(curies);
-  expect(descendants).not.toHaveProperty('DOID:0060527');
+  expect(descendants['DOID:0060527'].length).toBe(0);
+});
+
+test('recursive', () => {
+  let curies = ['UMLS:C0012634'];
+  let descendants = getDescendants(curies);
 });


### PR DESCRIPTION
https://github.com/biothings/biothings_explorer/issues/517

Uses a level order traversal to get the closest descendants of each curie. Added a entity cap 100 which might need to be lowered since it still times out with some queries but it shouldn't give the RangeError anymore.